### PR TITLE
samples: fix Request Context JSON sample - Publisher data is "pub" key

### DIFF
--- a/AdCOM v1.0 FINAL.md
+++ b/AdCOM v1.0 FINAL.md
@@ -4141,7 +4141,7 @@ This example is indicating a mobile optimized website and some basic details abo
                "domain": "examplesitedomain.com",
                "mobile": 1,
                "amp": 0,
-               "publisher": {
+               "pub": {
                   "id": "9876",
                   "name": "Example Publisher, Inc.",
                   "domain": "examplepubdomain.com"


### PR DESCRIPTION
[Appendix C: OpenRTB Interfaces](https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#appendix-c--openrtb-interfaces-) / [Request Context](https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#request-context-) sample seems to be out of sync with main spec:

- [Object: Site](https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#object_site)
- is derived from [Abstract Class: DistributionChannel](https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#abstract_distributionchannel)
- which exposes Publisher object as `pub` key (not `publisher`, as in [referenced Request Context sample](https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#request-context-))