### PR TITLE
samples: fix Item Specifications JSON sample - EventSpec.method is an array

### DIFF
--- a/AdCOM v1.0 FINAL.md
+++ b/AdCOM v1.0 FINAL.md
@@ -4222,7 +4222,7 @@ This example is indicating a display placement that must be secure.  Either a st
                         "event": [
                            {
                               "type": 1,
-                              "method": 1
+                              "method": [1]
                            }
                         ]
                      }


### PR DESCRIPTION
[Appendix C: OpenRTB Interfaces](https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#appendix-c--openrtb-interfaces-) / [Item Specifications](https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#item-specifications-) path `openrtb.request.item[0].spec.placement.display.event[0].method` resolves to `EventSpec.method` and should be an array:

- [Object: Placement](https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#object_placement) - `display` field
- [Object: DisplayPlacement](https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#object_displayplacement) - `event` field
- [Object: EventSpec](https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#object_eventspec) - `method` field