### PR TITLE
samples: fix ad.display.type -> .ctype

### DIFF
--- a/AdCOM v1.0 FINAL.md
+++ b/AdCOM v1.0 FINAL.md
@@ -4269,7 +4269,7 @@ This example is indicating a secure display ad for Ford using a structured banne
                            "secure": 1,
                            "display": {
                               "mime": "image/jpeg",
-                              "type": 3,
+                              "ctype": 3,
                               "w": 320,
                               "h": 50,
                               "banner": {


### PR DESCRIPTION
[Appendix C: OpenRTB Interfaces](https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#appendix-c--openrtb-interfaces-) / [Media Response](https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#media-response-) path `openrtb.response.seatbid[0].bid[0].media.ad.display.type` should be a `.ctype`, I believe:

- [Object: Ad](https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#object--ad-) - `display` prop
- [Object: Display](https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#object_display) - has no `type` prop, but a `ctype` ("Subtype of display creative") one
