### PR TITLE
Proposed `devicetype` to allow classifying OOH

### DIFF
--- a/AdCOM v1.0 FINAL.md
+++ b/AdCOM v1.0 FINAL.md
@@ -3178,6 +3178,10 @@ The following table lists the types of devices.  This table has values derived f
     <td>7</td>
     <td>Set Top Box</td>
   </tr>
+  <tr>
+    <td>8</td>
+    <td>OOH Device</td>
+  </tr>
 </table>
 
 


### PR DESCRIPTION
As part of the OOH extensions proposal, we would like to request an additional entry for `devicetype` to cover OOH devices