### PR TITLE
podid: integer -> string

### DIFF
--- a/AdCOM v1.0 FINAL.md
+++ b/AdCOM v1.0 FINAL.md
@@ -1490,7 +1490,7 @@ This object signals that the placement may be a video placement and provides add
   </tr>
   <tr>
   <td><code>podid</code></td>
-    <td>integer</td>
+    <td>string</td>
     <td>Unique identifier indicating that an impression opportunity belongs to a video ad pod. If multiple impression opportunities within a bid request share the same podid, this indicates that those impression opportunities belong to the same video ad pod.</td>
   </tr>
   <tr>
@@ -1657,7 +1657,7 @@ This object signals that the placement may be an audio placement and provides ad
   </tr>
   <tr>
   <td><code>podid</code></td>
-    <td>integer</td>
+    <td>string</td>
     <td>Unique identifier indicating that an impression opportunity belongs to a video ad pod. If multiple impression opportunities within a bid request share the same podid, this indicates that those impression opportunities belong to the same video ad pod.</td>
   </tr>
   <tr>


### PR DESCRIPTION
per change log of https://iabtechlab.com/wp-content/uploads/2022/04/OpenRTB-2-6_FINAL.pdf 

> "Updated July 2022 podid is a string, there was a conflict between the examples and the specification, the specification was incorrectly labeled integer"