### PR TITLE
Rename `Asset.image` to `Asset.img`.

### DIFF
--- a/AdCOM v1.0 FINAL.md
+++ b/AdCOM v1.0 FINAL.md
@@ -491,7 +491,7 @@ This object is the container for each asset comprising a native ad.  Each asset 
 * Required if no other asset subtype object is specified.</td>
   </tr>
   <tr>
-    <td><code>image</code></td>
+    <td><code>img</code></td>
     <td>object; required&nbsp;*</td>
     <td><strong>Asset Subtype Object</strong> that indicates this is an image asset and provides additional detail as such.  Refer to <a href="#object_imageasset">Object: ImageAsset</a>.<br/>
 * Required if no other asset subtype object is specified.</td>
@@ -5012,8 +5012,10 @@ Only minor fixes, such as clarifications or corrections to descriptions, may be 
 
 Granular details of the changes can be seen by reviewing the commit history of the document.
 
+**Rename "image" property of Asset to "img":** Rename "image" in Asset to "img" to match AssetFormat and the Native Ads Specification.
+
 **Clarification:** mccmnc description and rwdd description for clarity. (2022/03/25)
-      
+
 **Change of terminology:** References to "whitelist" have been changed to "allow list" consistent with industry norms. (2021/05/11)
 
 **Language improvements:** Word choice has been improved in places for clarity. (2020/02/14)


### PR DESCRIPTION
The `Asset` object defines image asset media under the `image` property. This is a mismatch against the naming convention used in the `AssetFormat` object as well as the `Asset` definition inside the native ads spec [1], which define the image format inside the `img` property.

[1] https://www.iab.com/wp-content/uploads/2018/03/OpenRTB-Native-Ads-Specification-Final-1.2.pdf