### PR TITLE
Add 51Degrees to the list of IP location providers

### DIFF
--- a/AdCOM v1.0 FINAL.md
+++ b/AdCOM v1.0 FINAL.md
@@ -3929,11 +3929,11 @@ The following table lists the services and/or vendors used for resolving IP addr
   </tr>
   <tr>
     <td>511</td>
-    <td>51Degrees (High Confidence: results can be relied upon and considered useful for all practical purposes)</td>
+    <td>51Degrees (High Confidence)</td>
   </tr>
   <tr>
     <td>512</td>
-    <td>51Degrees (Medium Confidence: results might be useful where the use case can tolerate a degree of inaccuracy)</td>
+    <td>51Degrees (Medium Confidence)</td>
   </tr>
 </table>
 

--- a/AdCOM v1.0 FINAL.md
+++ b/AdCOM v1.0 FINAL.md
@@ -3929,14 +3929,13 @@ The following table lists the services and/or vendors used for resolving IP addr
   </tr>
   <tr>
     <td>511</td>
-    <td>51Degrees (<a href="https://51degrees.com/documentation/4.5/_ip_intelligence__features__confidence.html">High Confidence</a>)</td>
+    <td>51Degrees (High Confidence: results can be relied upon and considered useful for all practical purposes)</td>
   </tr>
   <tr>
     <td>512</td>
-    <td>51Degrees (<a href="https://51degrees.com/documentation/4.5/_ip_intelligence__features__confidence.html">Medium Confidence</a>)</td>
+    <td>51Degrees (Medium Confidence: results might be useful where the use case can tolerate a degree of inaccuracy)</td>
   </tr>
 </table>
-
 
 ### List:  Linearity Modes <a name="list_linearitymodes"></a>
 

--- a/AdCOM v1.0 FINAL.md
+++ b/AdCOM v1.0 FINAL.md
@@ -3927,6 +3927,14 @@ The following table lists the services and/or vendors used for resolving IP addr
     <td>4</td>
     <td>NetAcuity (Digital Element)</td>
   </tr>
+  <tr>
+    <td>511</td>
+    <td>51Degrees (<a href="https://51degrees.com/documentation/4.5/_ip_intelligence__features__confidence.html">High Confidence</a>)</td>
+  </tr>
+  <tr>
+    <td>512</td>
+    <td>51Degrees (<a href="https://51degrees.com/documentation/4.5/_ip_intelligence__features__confidence.html">Medium Confidence</a>)</td>
+  </tr>
 </table>
 
 


### PR DESCRIPTION
Adds 51Degrees `High` and `Medium` confidence sources to the list of IP location providers. Note: Confidence is different to accuracy. 51Degrees can be confident a location result is within a large or small area.