### PR TITLE
Replace video with audio in AudioPlacement definition

### DIFF
--- a/AdCOM v1.0 FINAL.md
+++ b/AdCOM v1.0 FINAL.md
@@ -1625,7 +1625,7 @@ This object signals that the placement may be an audio placement and provides ad
   <tr>
     <td><code>rqddurs</code></td>
     <td>integer array</td>
-    <td>Precise acceptable durations for video creatives in seconds. This field specifically targets the Live TV use case where non-exact ad durations would result in undesirable 'dead air'. This field is mutually exclusive with mindur and maxdur; if rqddurs is specified, mindur and maxdur must not be specified and vice versa.</td>
+    <td>Precise acceptable durations for audio creatives in seconds. This field specifically targets the Live TV use case where non-exact ad durations would result in undesirable 'dead air'. This field is mutually exclusive with mindur and maxdur; if rqddurs is specified, mindur and maxdur must not be specified and vice versa.</td>
   </tr>
   <tr>
     <td><code>maxext</code></td>
@@ -1655,27 +1655,27 @@ This object signals that the placement may be an audio placement and provides ad
   <tr>
     <td><code>poddur</code></td>
     <td>integer</td>
-    <td>Indicates the total amount of time in seconds that advertisers may fill for a “dynamic” video ad pod, or the dynamic portion of a “hybrid” ad pod. This field is required only for the dynamic portion(s) of video ad pods. This field refers to the length of the entire ad break, whereas mindur/maxdur/rqddurs are constraints relating to the slots that make up the pod.</td>
+    <td>Indicates the total amount of time in seconds that advertisers may fill for a “dynamic” audio ad pod, or the dynamic portion of a “hybrid” ad pod. This field is required only for the dynamic portion(s) of audio ad pods. This field refers to the length of the entire ad break, whereas mindur/maxdur/rqddurs are constraints relating to the slots that make up the pod.</td>
   </tr>
   <tr>
   <td><code>podid</code></td>
     <td>integer</td>
-    <td>Unique identifier indicating that an impression opportunity belongs to a video ad pod. If multiple impression opportunities within a bid request share the same podid, this indicates that those impression opportunities belong to the same video ad pod.</td>
+    <td>Unique identifier indicating that an impression opportunity belongs to a audio ad pod. If multiple impression opportunities within a bid request share the same podid, this indicates that those impression opportunities belong to the same audio ad pod.</td>
   </tr>
   <tr>
   <td><code>podseq</code></td>
     <td>integer; default 0</td>
-    <td>The sequence (position) of the video ad pod within a content stream. Refer to List: <a href="#list_podsequence">List: Pod Sequence</a> for guidance on the use of this field.</td>
+    <td>The sequence (position) of the audio ad pod within a content stream. Refer to List: <a href="#list_podsequence">List: Pod Sequence</a> for guidance on the use of this field.</td>
   </tr>
   <tr>
   <td><code>slotinpod</code></td>
     <td>integer; default 0</td>
-    <td>For video ad pods, this value indicates that the seller can guarantee delivery against the indicated slot position in the pod. Refer to List: <a href="#list_slotpositioninpod">List: Slot Position in Pod</a> for guidance on the use of this field.</td>
+    <td>For audio ad pods, this value indicates that the seller can guarantee delivery against the indicated slot position in the pod. Refer to List: <a href="#list_slotpositioninpod">List: Slot Position in Pod</a> for guidance on the use of this field.</td>
   </tr>
   <tr>
   <td><code>mincpmpersec</code></td>
     <td>float</td>
-    <td>Minimum CPM per second. This is a price floor for the “dynamic” portion of a video ad pod, relative to the duration of bids an advertiser may submit.</td>
+    <td>Minimum CPM per second. This is a price floor for the “dynamic” portion of a audio ad pod, relative to the duration of bids an advertiser may submit.</td>
   </tr>
   <tr>
     <td><code>comp</code></td>


### PR DESCRIPTION
AudioPlacement definition incorrectly defines referenced creatives and pods as "video" instead of "audio".